### PR TITLE
Fixes NullPointerException when player won't join

### DIFF
--- a/src/main/java/me.petterim1.ns/NoSpaceInName.java
+++ b/src/main/java/me.petterim1.ns/NoSpaceInName.java
@@ -19,7 +19,10 @@ public class NoSpaceInName extends PluginBase implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void DataPacketReceiveEvent(DataPacketReceiveEvent e) {
         if (e.getPacket() instanceof LoginPacket) {
-            ((LoginPacket) e.getPacket()).username = ((LoginPacket) e.getPacket()).username.replace(" ", replaceWith);
+            LoginPacket packet = (LoginPacket) e.getPacket();
+            if (packet.username != null) {
+                packet.username = packet.username.replace(" ", replaceWith);
+            }
         }
     }
 }


### PR DESCRIPTION
https://github.com/PowerNukkit/PowerNukkit/issues/1339

> I managed to reproduce this issue. It happens when the player that is attempting to join is using an outdated client.
> 
> This is a plugin bug because it is assuming that the player received in `DataPacketReceiveEvent` will always have a name defined, but it may be `null`.

```java
cn.nukkit.utils.EventException: null
	at cn.nukkit.plugin.MethodEventExecutor.execute(MethodEventExecutor.java:35) ~[classes/:?]
	at cn.nukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:60) ~[classes/:?]
	at cn.nukkit.plugin.PluginManager.callEvent(PluginManager.java:572) [classes/:?]
	at cn.nukkit.Player.handleDataPacket(Player.java:2343) [classes/:?]
	at cn.nukkit.network.RakNetInterface.process(RakNetInterface.java:129) [classes/:?]
	at cn.nukkit.network.Network.processInterfaces(Network.java:170) [classes/:?]
	at cn.nukkit.Server.tick(Server.java:1363) [classes/:?]
	at cn.nukkit.Server.tickProcessor(Server.java:1146) [classes/:?]
	at cn.nukkit.Server.start(Server.java:1106) [classes/:?]
	at cn.nukkit.Server.<init>(Server.java:778) [classes/:?]
	at cn.nukkit.Nukkit.main(Nukkit.java:200) [classes/:?]
Caused by: java.lang.NullPointerException
	at me.petterim1.ns.NoSpaceInName.DataPacketReceiveEvent(NoSpaceInName.java:22) ~[?:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_312]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_312]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_312]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_312]
	at cn.nukkit.plugin.MethodEventExecutor.execute(MethodEventExecutor.java:30) ~[classes/:?]
	... 10 more
```